### PR TITLE
Fix a bug that relates to creating a new instance using self

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "config": {
     "platform": {
-      "php": "7.4"
+      "php": "8.0"
     }
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eee0ba07948c8ad3aaffacb67e046a41",
+    "content-hash": "bfdc6a7197cf48a40f37e1e3241a5d14",
     "packages": [],
     "packages-dev": [
         {
@@ -3755,13 +3755,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
-        "php": "7.4"
+        "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    phpVersion="7.4"
+    phpVersion="8.0"
     errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/Number/Integer.php
+++ b/src/Number/Integer.php
@@ -28,7 +28,7 @@ class Integer extends AbstractType
     final public static function fromNumeric($value): self
     {
         if (is_numeric($value)) {
-            return new self((int)$value);
+            return new static((int)$value);
         }
 
         throw new InvalidArgumentException('Value is not numeric.');

--- a/src/Number/Integer.php
+++ b/src/Number/Integer.php
@@ -11,8 +11,9 @@ class Integer extends AbstractType
 {
     private int $value;
 
-    public function __construct(int $value)
+    final public function __construct(int $value)
     {
+        $this->validate($value);
         $this->value = $value;
     }
 
@@ -25,12 +26,17 @@ class Integer extends AbstractType
      * @param int|float|string $value
      * @return static
      */
-    final public static function fromNumeric($value): self
+    final public static function fromNumeric($value): static
     {
         if (is_numeric($value)) {
             return new static((int)$value);
         }
 
         throw new InvalidArgumentException('Value is not numeric.');
+    }
+
+    protected function validate(int $value): void
+    {
+        // Integer does nothing.
     }
 }

--- a/src/Number/NonNegativeInteger.php
+++ b/src/Number/NonNegativeInteger.php
@@ -8,12 +8,10 @@ use InvalidArgumentException;
 
 class NonNegativeInteger extends Integer
 {
-    public function __construct(int $value)
+    protected function validate(int $value): void
     {
         if ($value < 0) {
             throw new InvalidArgumentException('Value must be a non negative integer');
         }
-
-        parent::__construct($value);
     }
 }

--- a/src/Number/PositiveInteger.php
+++ b/src/Number/PositiveInteger.php
@@ -8,12 +8,10 @@ use InvalidArgumentException;
 
 class PositiveInteger extends Integer
 {
-    public function __construct(int $value)
+    protected function validate(int $value): void
     {
         if ($value <= 0) {
             throw new InvalidArgumentException('Value must be a positive integer');
         }
-
-        parent::__construct($value);
     }
 }

--- a/tests/Number/NonNegativeIntegerTest.php
+++ b/tests/Number/NonNegativeIntegerTest.php
@@ -72,4 +72,25 @@ final class NonNegativeIntegerTest extends TestCase
         $this->assertFalse($integer1->equals($integer2));
         $this->assertFalse($integer2->equals($integer1));
     }
+
+    public function test_canNotBeCreatedFromNegativeNumericString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        NonNegativeInteger::fromNumeric('-42');
+    }
+
+    public function test_canNotBeCreatedFromNegativeFloat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $result = NonNegativeInteger::fromNumeric(-42.3);
+    }
+
+    public function test_canNotBeCreatedFromNegativeNumeric(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        NonNegativeInteger::fromNumeric(-42);
+    }
 }

--- a/tests/Number/PositiveIntegerTest.php
+++ b/tests/Number/PositiveIntegerTest.php
@@ -73,4 +73,32 @@ final class PositiveIntegerTest extends TestCase
         $this->assertFalse($integer1->equals($integer2));
         $this->assertFalse($integer2->equals($integer1));
     }
+
+    public function test_CannotBeCreatedFromNumericZeroString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PositiveInteger::fromNumeric('0');
+    }
+
+    public function test_CannotBeCreatedFromNumericZeroFloat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PositiveInteger::fromNumeric(0.0);
+    }
+
+    public function test_CannotBeCreatedFromNumericNegativeIntegerString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PositiveInteger::fromNumeric('-1');
+    }
+
+    public function test_CannotBeCreatedFromNumericNegativeInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PositiveInteger::fromNumeric(-1);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue that lets us create a `PositiveInteger` with values [-inf, 0] and `NonNegativeInteger` with values [-inf].

The issue occurs when we use the `fromNumeric` static method which uses `self::` instead of `static::` to create the instance, thus using the constructor of the parent class in which `fromNumeric` is defined and doesn't contain the validation logic.